### PR TITLE
カテゴリ編集機能を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "aws-amplify": "^3.3.15",
     "clsx": "^1.1.1",
     "date-fns": "^2.17.0",
+    "fast-deep-equal": "^3.1.3",
     "i18next": "^19.8.7",
     "lodash": "^4.17.20",
     "react": "^17.0.1",
@@ -22,6 +23,7 @@
     "react-i18next": "^11.8.5",
     "react-redux": "^7.2.2",
     "react-router-dom": "^5.2.0",
+    "react-sortable-hoc": "^1.11.0",
     "web-vitals": "^0.2.4"
   },
   "devDependencies": {
@@ -35,6 +37,7 @@
     "@types/react-dom": "^16.9.8",
     "@types/react-redux": "^7.1.16",
     "@types/react-router-dom": "^5.1.7",
+    "@types/sortablejs": "^1.10.6",
     "@typescript-eslint/eslint-plugin": "^4.14.2",
     "@typescript-eslint/parser": "^4.14.2",
     "eslint-config-airbnb": "^18.2.1",

--- a/src/Route.tsx
+++ b/src/Route.tsx
@@ -2,9 +2,10 @@
 import React from "react";
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 import { AuthState } from "@aws-amplify/ui-components";
-import Profile from "./features/user";
-import Home from "./features/home";
 import Auth from "./features/auth/Auth";
+import Home from "./features/home";
+import Categories from "./features/categories";
+import Profile from "./features/user";
 
 interface WithRouteProps {
   children: React.ReactNode;
@@ -23,6 +24,9 @@ const AppWithRoute = (props: WithRouteProps): JSX.Element => {
           <Home />
         </Route>
         <Auth>
+          <Route exact path="/categories">
+            <Categories />
+          </Route>
           <Route exact path="/settings">
             <Profile />
           </Route>

--- a/src/component/header/I18nButton.tsx
+++ b/src/component/header/I18nButton.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react'
-import i18n from 'i18next'
-import { useDispatch } from 'react-redux'
+import React, { useState } from "react";
+import i18n from "i18next";
+import { useDispatch } from "react-redux";
 import {
   createStyles,
   IconButton,
@@ -9,9 +9,9 @@ import {
   Menu,
   MenuItem,
   Theme,
-} from '@material-ui/core'
-import LanguageIcon from '@material-ui/icons/Language'
-import { setLocale } from '../../features/i18n/i18nSlice'
+} from "@material-ui/core";
+import LanguageIcon from "@material-ui/icons/Language";
+import { setLocale } from "../../features/i18n/i18nSlice";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -19,32 +19,32 @@ const useStyles = makeStyles((theme: Theme) =>
       marginLeft: theme.spacing(1),
     },
   }),
-)
+);
 
 const i18nList = [
-  { value: 'en', label: 'English' },
-  { value: 'ja', label: '日本語' },
-]
+  { value: "en", label: "English" },
+  { value: "ja", label: "日本語" },
+];
 
 // TODO:locale list も引数で受け取る
 // eslint-disable-next-line import/prefer-default-export
 export const I18nMenu = (): JSX.Element => {
-  const classes = useStyles()
-  const dispatch = useDispatch()
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
+  const classes = useStyles();
+  const dispatch = useDispatch();
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const handleI18nIconClick = (
     event: React.MouseEvent<HTMLButtonElement>,
   ): void => {
-    setAnchorEl(event.currentTarget)
-  }
+    setAnchorEl(event.currentTarget);
+  };
   const handleI18nClose = (): void => {
-    setAnchorEl(null)
-  }
+    setAnchorEl(null);
+  };
   const handleI18nClick = (value: string): void => {
-    const n = dispatch(setLocale(value)).payload
-    i18n.changeLanguage(n)
-    setAnchorEl(null)
-  }
+    const n = dispatch(setLocale(value)).payload;
+    i18n.changeLanguage(n);
+    setAnchorEl(null);
+  };
   return (
     <>
       <IconButton
@@ -71,5 +71,5 @@ export const I18nMenu = (): JSX.Element => {
         ))}
       </Menu>
     </>
-  )
-}
+  );
+};

--- a/src/component/header/menu.tsx
+++ b/src/component/header/menu.tsx
@@ -16,35 +16,35 @@ export interface MenuObject {
 }
 
 const menuItems: MenuObject[] = [
-  // {
-  //   key: "c_kakeibo",
-  //   priority: 0,
-  //   label: "MENU_LABEL_KAKEIBO",
-  //   icon: <AccountBalanceWalletIcon />,
-  //   children: [
-  //     {
-  //       key: "input",
-  //       priority: 0,
-  //       label: "MENU_LABEL_FORM",
-  //       icon: <EditIcon />,
-  //       linkTo: "/input",
-  //     },
-  //     {
-  //       key: "output",
-  //       priority: 1,
-  //       label: "MENU_LABEL_LIST",
-  //       linkTo: "/output",
-  //       icon: <ListIcon />,
-  //     },
-  //     {
-  //       key: "manage_category",
-  //       priority: 2,
-  //       label: "MENU_LABEL_CATEGORIES",
-  //       linkTo: "/categories",
-  //       icon: <CategoryIcon />,
-  //     },
-  //   ],
-  // },
+  {
+    key: "c_kakeibo",
+    priority: 0,
+    label: "MENU_LABEL_KAKEIBO",
+    icon: <AccountBalanceWalletIcon />,
+    children: [
+      //     {
+      //       key: "input",
+      //       priority: 0,
+      //       label: "MENU_LABEL_FORM",
+      //       icon: <EditIcon />,
+      //       linkTo: "/input",
+      //     },
+      //     {
+      //       key: "output",
+      //       priority: 1,
+      //       label: "MENU_LABEL_LIST",
+      //       linkTo: "/output",
+      //       icon: <ListIcon />,
+      //     },
+      {
+        key: "manage_category",
+        priority: 2,
+        label: "MENU_LABEL_CATEGORIES",
+        linkTo: "/categories",
+        icon: <CategoryIcon />,
+      },
+    ],
+  },
   // {
   //   key: "todos",
   //   priority: 1,

--- a/src/features/categories/CategoryEditMenu.tsx
+++ b/src/features/categories/CategoryEditMenu.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import equal from "fast-deep-equal/react";
+import { Menu, MenuItem } from "@material-ui/core";
+import { ICategory } from "../../types";
+
+interface ICategoryEditMenu {
+  el: null | HTMLElement;
+  open: boolean;
+  category: ICategory;
+  onClose: () => void;
+  onDisableClick: () => void;
+  onRemoveClick: () => void;
+}
+
+const CategoryEditMenu = React.memo(
+  ({
+    el,
+    open,
+    category,
+    onClose,
+    onDisableClick,
+    onRemoveClick,
+  }: ICategoryEditMenu): JSX.Element => {
+    const { t } = useTranslation();
+    const handleCloseMenu = () => {
+      onClose();
+    };
+    const handleDisableClick = () => {
+      onDisableClick();
+      handleCloseMenu();
+    };
+    const handleRemoveClick = () => {
+      onRemoveClick();
+      handleCloseMenu();
+    };
+
+    return (
+      <Menu
+        anchorEl={el}
+        open={Boolean(el && open)}
+        onClose={handleCloseMenu}
+        PaperProps={{
+          elevation: 3,
+        }}
+      >
+        <MenuItem onClick={handleDisableClick} dense>
+          {t(category.disabled ? "LABEL_ACTIVATION" : "LABEL_INVALIDATION")}
+        </MenuItem>
+        <MenuItem onClick={handleRemoveClick} dense>
+          {t("LABEL_DELETE")}
+        </MenuItem>
+      </Menu>
+    );
+  },
+  equal,
+);
+
+export default CategoryEditMenu;

--- a/src/features/categories/CategoryForm.tsx
+++ b/src/features/categories/CategoryForm.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Grid,
+  Paper,
+  Backdrop,
+  CircularProgress,
+  makeStyles,
+  createStyles,
+  Theme,
+  Button,
+} from "@material-ui/core";
+import clsx from "clsx";
+import CategoryList from "./CategoryList";
+import { ISnackBarBase, SnackBar } from "../../component/parts";
+import { ICategory } from "../../types";
+
+interface ISnackBarState extends ISnackBarBase {
+  open: boolean;
+  onClose: () => void;
+}
+interface ICategoryForm {
+  categories: ICategory[];
+  onEditCategories: (categories: ICategory[]) => void;
+  onSubmitClick: () => void;
+  loading: boolean;
+  snackbar: ISnackBarState;
+}
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    backdrop: {
+      zIndex: theme.zIndex.drawer + 1,
+    },
+  }),
+);
+
+const divClass = clsx("input-wrapper");
+const paperClass = clsx("underlay-paper-base");
+const formClass = clsx("column-container");
+const updateButtonClass = clsx("input-field-base");
+
+const CategoryForm = ({
+  categories,
+  onEditCategories,
+  onSubmitClick,
+  loading,
+  snackbar,
+}: ICategoryForm): JSX.Element => {
+  const { t } = useTranslation();
+  const classes = useStyles();
+
+  return (
+    <div className={divClass}>
+      <Paper className={paperClass}>
+        <Grid container direction="column" alignItems="center">
+          <Grid item xs={10}>
+            <div className={formClass}>
+              <CategoryList
+                categories={categories}
+                onEditCategories={onEditCategories}
+              />
+              <Button
+                color="secondary"
+                variant="outlined"
+                onClick={onSubmitClick}
+                className={updateButtonClass}
+              >
+                {t("LABEL_SAVE")}
+              </Button>
+            </div>
+          </Grid>
+        </Grid>
+      </Paper>
+      {/* controles */}
+      <Backdrop open={loading} className={classes.backdrop}>
+        <CircularProgress color="secondary" size={80} />
+      </Backdrop>
+      <SnackBar
+        open={snackbar.open}
+        message={snackbar.message}
+        severity={snackbar.severity}
+        closable
+        autoHideDuration={snackbar.autoHideDuration}
+        handleClose={snackbar.onClose}
+      />
+    </div>
+  );
+};
+
+export default CategoryForm;

--- a/src/features/categories/CategoryItem.tsx
+++ b/src/features/categories/CategoryItem.tsx
@@ -1,0 +1,149 @@
+import React, { useState } from "react";
+import equal from "fast-deep-equal/es6/react";
+import { IconButton, TextField } from "@material-ui/core";
+import AddIcon from "@material-ui/icons/Add";
+import MoreVertIcon from "@material-ui/icons/MoreVert";
+import { isN999 } from "../../utils";
+import { ICategory } from "../../types";
+import CategoryEditMenu from "./CategoryEditMenu";
+
+// #region Interface
+interface ICategoryItemBase {
+  item: ICategory;
+}
+interface ICategoryItem extends ICategoryItemBase {
+  onChangeName?: (value: string | undefined) => void;
+}
+export interface IBaseCategoryItem extends ICategoryItem {
+  endAdornment?: React.ReactElement;
+}
+export interface INormalCategoryItem extends ICategoryItem {
+  onDisableClick: () => void;
+  onRemoveClick: () => void;
+}
+export interface IN999CategoryItem extends ICategoryItemBase {
+  onAddClick: () => void;
+}
+// #endregion
+export const endAddornmentClass = "edit-categories-add-button";
+
+// #region BaseCategoryItem
+const BaseItem = ({
+  item,
+  onChangeName,
+  endAdornment,
+}: IBaseCategoryItem): JSX.Element => {
+  // console.log("render base");
+  const handleNameChange = (
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    if (onChangeName && typeof onChangeName === "function")
+      onChangeName(event.target.value);
+  };
+
+  return (
+    <>
+      <TextField
+        value={item.name}
+        InputProps={{
+          readOnly: isN999(item),
+        }}
+        margin="none"
+        size="small"
+        disabled={item.disabled}
+        onChange={handleNameChange}
+      />
+      {endAdornment}
+    </>
+  );
+};
+const BaseCategoryItem = React.memo(BaseItem, (prev, next) =>
+  equal(prev, next),
+);
+// #endregion
+
+// #region NormalCategoryItem
+const NormalItem = ({
+  item,
+  onChangeName,
+  onDisableClick,
+  onRemoveClick,
+}: INormalCategoryItem): JSX.Element => {
+  // console.log("render normal");
+  const [el, setEl] = useState<null | HTMLElement>(null);
+  const handleMenuOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setEl(event.currentTarget);
+  };
+  const handleMenuClose = () => {
+    setEl(null);
+  };
+  const handleDisableClick = () => {
+    onDisableClick();
+    handleMenuClose();
+  };
+  const handleRemoveClick = () => {
+    onRemoveClick();
+    handleMenuClose();
+  };
+  const endAdornment = (
+    <IconButton
+      onClick={handleMenuOpen}
+      size="small"
+      className={endAddornmentClass}
+    >
+      <MoreVertIcon />
+    </IconButton>
+  );
+  return (
+    <>
+      <BaseCategoryItem
+        item={item}
+        onChangeName={onChangeName}
+        endAdornment={endAdornment}
+      />
+      <CategoryEditMenu
+        el={el}
+        open={Boolean(el)}
+        category={item}
+        onClose={handleMenuClose}
+        onDisableClick={handleDisableClick}
+        onRemoveClick={handleRemoveClick}
+      />
+    </>
+  );
+};
+export const NormalCategoryItem = React.memo(NormalItem, (prev, next) =>
+  equal(prev, next),
+);
+// #endregion
+
+// #region N999CategoryItem
+const N999Item = ({ item, onAddClick }: IN999CategoryItem): JSX.Element => {
+  // console.log("render n999");
+  const endAdornment = (
+    <IconButton
+      onClick={onAddClick}
+      size="small"
+      className={endAddornmentClass}
+    >
+      <AddIcon />
+    </IconButton>
+  );
+  return <BaseCategoryItem item={item} endAdornment={endAdornment} />;
+};
+export const N999CategoryItem = React.memo(N999Item, (prev, next) =>
+  equal(prev, next),
+);
+// #endregion
+
+// #region default props
+const defaults = {
+  onChangeName: () => null,
+};
+BaseItem.defaultProps = {
+  ...defaults,
+  endAdornment: null,
+};
+NormalItem.defaultProps = defaults;
+// #endregion
+export default BaseCategoryItem;

--- a/src/features/categories/CategoryList.tsx
+++ b/src/features/categories/CategoryList.tsx
@@ -1,0 +1,132 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React from "react";
+import {
+  SortableContainer,
+  SortableElement,
+  SortableHandle,
+} from "react-sortable-hoc";
+import { IconButton, SvgIcon } from "@material-ui/core";
+import DragHandleIcon from "@material-ui/icons/DragHandle";
+import _ from "lodash";
+import {
+  endAddornmentClass,
+  IN999CategoryItem,
+  INormalCategoryItem,
+  N999CategoryItem,
+  NormalCategoryItem,
+} from "./CategoryItem";
+import { isN999 } from "../../utils";
+import { ICategory } from "../../types";
+import settings from "../../settings";
+
+const getBaseCategory = (): ICategory => ({
+  id: settings.constants.newId + performance.now(),
+  name: "",
+  disabled: false,
+});
+
+interface ICategoryLista {
+  items: ICategory[];
+  onEditCategories: (categories: ICategory[]) => void;
+}
+
+interface ICategoryList {
+  categories: ICategory[];
+  onEditCategories: (categories: ICategory[]) => void;
+}
+
+const DragHandle = SortableHandle(
+  ({
+    iconElem,
+    disabled,
+  }: {
+    iconElem: React.ReactElement;
+    disabled?: boolean;
+  }) => (
+    <IconButton disabled={disabled} className={endAddornmentClass}>
+      {iconElem}
+    </IconButton>
+  ),
+);
+
+const SortableN999 = SortableElement((props: IN999CategoryItem) => (
+  <div>
+    <DragHandle iconElem={<SvgIcon />} disabled />
+    <N999CategoryItem {...props} />
+  </div>
+));
+
+const SortableNormal = SortableElement((props: INormalCategoryItem) => (
+  <div>
+    <DragHandle iconElem={<DragHandleIcon />} />
+    <NormalCategoryItem {...props} />
+  </div>
+));
+
+const CategoryList = ({
+  items,
+  onEditCategories,
+}: ICategoryLista): JSX.Element => {
+  const handleNameChange = (index: number) => (value: string | undefined) => {
+    const newArray = _.cloneDeep(items);
+    newArray[index].name = value || "";
+    onEditCategories(newArray);
+  };
+  const handleAdd = () => {
+    const newArray = _.cloneDeep(items);
+    newArray.splice(newArray.length - 1, 0, getBaseCategory());
+    onEditCategories(newArray);
+  };
+  const handleDisableClick = (index: number, disabled: boolean) => () => {
+    const newArray = _.cloneDeep(items);
+    newArray[index].disabled = disabled;
+    onEditCategories(newArray);
+  };
+  const handleRemoveClick = (index: number) => () => {
+    const newArray = _.cloneDeep(items.filter((item, i) => i !== index));
+    onEditCategories(newArray);
+  };
+
+  return (
+    // divがないとsortableできない
+    <div>
+      {items.map((category, index) =>
+        isN999(category) ? (
+          <SortableN999
+            disabled
+            key={`category-item-${category.id}`}
+            item={category}
+            index={index}
+            onAddClick={handleAdd}
+          />
+        ) : (
+          <SortableNormal
+            key={`category-item-${category.id}`}
+            item={category}
+            index={index}
+            onChangeName={handleNameChange(index)}
+            onDisableClick={handleDisableClick(index, !category.disabled)}
+            onRemoveClick={handleRemoveClick(index)}
+          />
+        ),
+      )}
+    </div>
+  );
+};
+
+const SortableList = SortableContainer(CategoryList);
+
+// TODO: 順番入れ替えロジック
+const SortableCategoryList = ({
+  categories,
+  onEditCategories,
+}: ICategoryList): JSX.Element => (
+  <SortableList
+    items={categories}
+    lockAxis="y"
+    useDragHandle
+    onEditCategories={onEditCategories}
+  />
+);
+
+export default SortableCategoryList;

--- a/src/features/categories/CategoryList.tsx
+++ b/src/features/categories/CategoryList.tsx
@@ -18,6 +18,7 @@ import {
 import { isN999 } from "../../utils";
 import { ICategory } from "../../types";
 import settings from "../../settings";
+import { arrayMoveClone } from "../../utils/arrayUtil";
 
 const getBaseCategory = (): ICategory => ({
   id: settings.constants.newId + performance.now(),
@@ -126,6 +127,10 @@ const SortableCategoryList = ({
     lockAxis="y"
     useDragHandle
     onEditCategories={onEditCategories}
+    onSortEnd={({ oldIndex, newIndex }) => {
+      const newArray = arrayMoveClone(categories, oldIndex, newIndex);
+      onEditCategories(newArray);
+    }}
   />
 );
 

--- a/src/features/categories/controller.tsx
+++ b/src/features/categories/controller.tsx
@@ -1,0 +1,85 @@
+import React, { useState, useEffect } from "react";
+import { useSelector } from "react-redux";
+import { ISnackBarBase } from "../../component/parts";
+import { selectCurrentGroup } from "../group/groupSlice";
+import { createCategories, fetchCategories } from "../../api";
+import { createSnackState, isApiError } from "../../utils";
+import { ICategory, IApiResponseBase } from "../../types";
+import settings from "../../settings";
+import CategoryForm from "./CategoryForm";
+
+const filterNew = (categories: ICategory[]): ICategory[] =>
+  categories.map(item =>
+    item.id.startsWith(settings.constants.newId)
+      ? { ...item, ...{ id: "" } }
+      : { ...item },
+  );
+
+const CategoriesController = (): JSX.Element => {
+  const currentGroup = useSelector(selectCurrentGroup);
+  const [categories, setCategories] = useState<ICategory[]>([]);
+  const [refresh, setRefresh] = useState<boolean>(false);
+  const [sending, setSending] = useState<boolean>(false);
+  const [snackOpen, setSnackOpen] = useState<boolean>(false);
+  const [snack, setSnack] = useState<ISnackBarBase>({
+    message: "",
+    severity: "success",
+    closable: true,
+  });
+
+  useEffect(() => {
+    setSending(true);
+    const getDatas = async () => {
+      const data = [
+        { id: "aaa", name: "家具", disabled: false },
+        { id: "bbb", name: "食費", disabled: false },
+        { id: "N_999", name: "その他", disabled: false },
+      ];
+      setCategories(data);
+      // await fetchCategories(currentGroup.id)
+      // const { error, message } = isApiError(data, true)
+      // if (error) {
+      //   setSnack(createSnackState(error, message))
+      //   setSnackOpen(true)
+      // } else {
+      //   setCategories(data.body || [])
+      // }
+      setSending(false);
+    };
+    getDatas();
+  }, [refresh, currentGroup]);
+
+  const responseHandler = (
+    res: IApiResponseBase<undefined>,
+    withBody?: boolean,
+  ) => {
+    const { error, message } = isApiError(res, withBody);
+    setSnack(createSnackState(error, message));
+    setSnackOpen(true);
+    setRefresh(!refresh);
+  };
+
+  const handlePost = async () => {
+    setSending(true);
+    const newArray = filterNew(categories);
+    const res = await createCategories(newArray, currentGroup.id);
+    setSending(false);
+    responseHandler(res);
+  };
+
+  return (
+    <CategoryForm
+      categories={categories}
+      onEditCategories={setCategories}
+      onSubmitClick={handlePost}
+      loading={sending}
+      snackbar={{
+        ...snack,
+        open: snackOpen,
+        onClose: () => setSnackOpen(false),
+      }}
+    />
+  );
+};
+
+export default CategoriesController;

--- a/src/features/categories/controller.tsx
+++ b/src/features/categories/controller.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useSelector } from "react-redux";
+import { isEmpty } from "lodash";
 import { ISnackBarBase } from "../../component/parts";
 import { selectCurrentGroup } from "../group/groupSlice";
 import { createCategories, fetchCategories } from "../../api";
@@ -36,7 +37,7 @@ const CategoriesController = (): JSX.Element => {
         setSnack(createSnackState(error, message));
         setSnackOpen(true);
       } else {
-        setCategories(data.body || []);
+        setCategories(data.body && !isEmpty(data.body) ? data.body : []);
       }
       setSending(false);
     };

--- a/src/features/categories/controller.tsx
+++ b/src/features/categories/controller.tsx
@@ -30,20 +30,14 @@ const CategoriesController = (): JSX.Element => {
   useEffect(() => {
     setSending(true);
     const getDatas = async () => {
-      const data = [
-        { id: "aaa", name: "家具", disabled: false },
-        { id: "bbb", name: "食費", disabled: false },
-        { id: "N_999", name: "その他", disabled: false },
-      ];
-      setCategories(data);
-      // await fetchCategories(currentGroup.id)
-      // const { error, message } = isApiError(data, true)
-      // if (error) {
-      //   setSnack(createSnackState(error, message))
-      //   setSnackOpen(true)
-      // } else {
-      //   setCategories(data.body || [])
-      // }
+      const data = await fetchCategories(currentGroup.id);
+      const { error, message } = isApiError(data, true);
+      if (error) {
+        setSnack(createSnackState(error, message));
+        setSnackOpen(true);
+      } else {
+        setCategories(data.body || []);
+      }
       setSending(false);
     };
     getDatas();

--- a/src/features/categories/index.tsx
+++ b/src/features/categories/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import Controller from './controller'
+import Me from '../user/Me'
+import Group from '../group/Group'
+
+export default (): JSX.Element => (
+  <Me>
+    <Group>
+      <Controller />
+    </Group>
+  </Me>
+)

--- a/src/features/categories/index.tsx
+++ b/src/features/categories/index.tsx
@@ -1,7 +1,7 @@
-import React from 'react'
-import Controller from './controller'
-import Me from '../user/Me'
-import Group from '../group/Group'
+import React from "react";
+import Controller from "./controller";
+import Me from "../user/Me";
+import Group from "../group/Group";
 
 export default (): JSX.Element => (
   <Me>
@@ -9,4 +9,4 @@ export default (): JSX.Element => (
       <Controller />
     </Group>
   </Me>
-)
+);

--- a/src/features/i18n/resource.type.ts
+++ b/src/features/i18n/resource.type.ts
@@ -43,6 +43,8 @@ export interface II18n {
   LABEL_SIGNUP: string;
   LABEL_INVITE: string;
   LABEL_EXIT_GROUP: string;
+  LABEL_ACTIVATION: string;
+  LABEL_INVALIDATION: string;
   // menu labels
   MENU_LABEL_KAKEIBO: string;
   MENU_LABEL_FORM: string;

--- a/src/features/i18n/resource_en.ts
+++ b/src/features/i18n/resource_en.ts
@@ -46,6 +46,8 @@ const en: II18n = {
   LABEL_SIGNUP: "Sign Up",
   LABEL_INVITE: "Invite",
   LABEL_EXIT_GROUP: "Exit Group",
+  LABEL_ACTIVATION: "Enable",
+  LABEL_INVALIDATION: "Disable",
   // menu labels
   MENU_LABEL_KAKEIBO: "Wallet",
   MENU_LABEL_FORM: "Form",

--- a/src/features/i18n/resource_ja.ts
+++ b/src/features/i18n/resource_ja.ts
@@ -46,6 +46,8 @@ const ja: II18n = {
   LABEL_SIGNUP: "サインアップ",
   LABEL_INVITE: "招待",
   LABEL_EXIT_GROUP: "退会する",
+  LABEL_ACTIVATION: "有効化",
+  LABEL_INVALIDATION: "無効化",
   // menu labels
   MENU_LABEL_KAKEIBO: "家計簿",
   MENU_LABEL_FORM: "入力",

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -1,15 +1,15 @@
+export interface ICategory {
+  id: string;
+  name: string;
+  disabled: boolean;
+}
+
 export interface ICurrentUser {
   email: string;
   id: string;
   name: string;
   avatar: string;
   groups: IGroup[];
-}
-
-export interface ICategory {
-  id: string;
-  name: string;
-  disabled: boolean;
 }
 
 export interface IGroupBase {

--- a/src/utils/arrayUtil.test.ts
+++ b/src/utils/arrayUtil.test.ts
@@ -1,0 +1,64 @@
+import { arrayMoveClone, arrayMoveMutate } from "./arrayUtil";
+
+const fixture = () => [
+  { id: 1, name: "a" },
+  { id: 2, name: "b" },
+  { id: 3, name: "c" },
+  { id: 4, name: "d" },
+  { id: 5, name: "e" },
+];
+
+describe("* arrayUtil ", () => {
+  test("* arrayMoveByClone", () => {
+    const base = fixture();
+    expect(arrayMoveClone(base, 3, 0)).toEqual([
+      { id: 4, name: "d" },
+      { id: 1, name: "a" },
+      { id: 2, name: "b" },
+      { id: 3, name: "c" },
+      { id: 5, name: "e" },
+    ]);
+    expect(arrayMoveClone(base, -1, 0)).toEqual([
+      { id: 5, name: "e" },
+      { id: 1, name: "a" },
+      { id: 2, name: "b" },
+      { id: 3, name: "c" },
+      { id: 4, name: "d" },
+    ]);
+    expect(arrayMoveClone(base, 1, -2)).toEqual([
+      { id: 1, name: "a" },
+      { id: 3, name: "c" },
+      { id: 4, name: "d" },
+      { id: 2, name: "b" },
+      { id: 5, name: "e" },
+    ]);
+    expect(arrayMoveClone(base, -3, -4)).toEqual([
+      { id: 1, name: "a" },
+      { id: 3, name: "c" },
+      { id: 2, name: "b" },
+      { id: 4, name: "d" },
+      { id: 5, name: "e" },
+    ]);
+    expect(arrayMoveClone(base, 5, 6)).toEqual([
+      { id: 1, name: "a" },
+      { id: 2, name: "b" },
+      { id: 3, name: "c" },
+      { id: 4, name: "d" },
+      { id: 5, name: "e" },
+    ]);
+    expect(arrayMoveClone(base, -1000, 0)).toEqual(fixture());
+    expect(arrayMoveClone(base, 1000, 0)).toEqual(fixture());
+    expect(base).toEqual(fixture());
+  });
+  test("* arrayMoveMutate", () => {
+    const base = fixture();
+    arrayMoveMutate(base, 3, 0);
+    expect(base).toEqual([
+      { id: 4, name: "d" },
+      { id: 1, name: "a" },
+      { id: 2, name: "b" },
+      { id: 3, name: "c" },
+      { id: 5, name: "e" },
+    ]);
+  });
+});

--- a/src/utils/arrayUtil.ts
+++ b/src/utils/arrayUtil.ts
@@ -1,0 +1,26 @@
+import { cloneDeep } from "lodash";
+
+export const arrayMoveMutate = <T>(
+  array: T[],
+  from: number,
+  to: number,
+): void => {
+  const startIndex = from < 0 ? array.length + from : from;
+
+  if (startIndex >= 0 && startIndex < array.length) {
+    const endIndex = to < 0 ? array.length + to : to;
+
+    const [item] = array.splice(from, 1);
+    array.splice(endIndex, 0, item);
+  }
+};
+
+export const arrayMoveClone = <T>(
+  array: T[],
+  from: number,
+  to: number,
+): T[] => {
+  const newArray = cloneDeep(array);
+  arrayMoveMutate(newArray, from, to);
+  return newArray;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2381,7 +2381,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.6.0":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.2.0", "@babel/runtime@^7.6.0":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.13.tgz#0a21452352b02542db0ffb928ac2d3ca7cb6d66d"
   integrity sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==
@@ -3345,6 +3345,11 @@
   integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
   dependencies:
     "@types/node" "*"
+
+"@types/sortablejs@^1.10.6":
+  version "1.10.6"
+  resolved "https://registry.yarnpkg.com/@types/sortablejs/-/sortablejs-1.10.6.tgz#98725ae08f1dfe28b8da0fdf302c417f5ff043c0"
+  integrity sha512-QRz8Z+uw2Y4Gwrtxw8hD782zzuxxugdcq8X/FkPsXUa1kfslhGzy13+4HugO9FXNo+jlWVcE6DYmmegniIQ30A==
 
 "@types/source-list-map@*":
   version "0.1.2"
@@ -6647,7 +6652,7 @@ fast-base64-decode@^1.0.0:
   resolved "https://registry.yarnpkg.com/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz#b434a0dd7d92b12b43f26819300d2dafb83ee418"
   integrity sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -7637,6 +7642,13 @@ internal-slot@^1.0.2:
     es-abstract "^1.17.0-next.1"
     has "^1.0.3"
     side-channel "^1.0.2"
+
+invariant@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
+  dependencies:
+    loose-envify "^1.0.0"
 
 ip-regex@^2.1.0:
   version "2.1.0"
@@ -8975,7 +8987,7 @@ lolex@^5.0.0, lolex@^5.0.1:
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -10845,7 +10857,7 @@ prompts@2.4.0, prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.7, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -11203,6 +11215,15 @@ react-scripts@4.0.1:
     workbox-webpack-plugin "5.1.4"
   optionalDependencies:
     fsevents "^2.1.3"
+
+react-sortable-hoc@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/react-sortable-hoc/-/react-sortable-hoc-1.11.0.tgz#fe4022362bbafc4b836f5104b9676608a40a278f"
+  integrity sha512-v1CDCvdfoR3zLGNp6qsBa4J1BWMEVH25+UKxF/RvQRh+mrB+emqtVHMgZ+WreUiKJoEaiwYoScaueIKhMVBHUg==
+  dependencies:
+    "@babel/runtime" "^7.2.0"
+    invariant "^2.2.4"
+    prop-types "^15.5.7"
 
 react-transition-group@^4.0.0, react-transition-group@^4.4.0:
   version "4.4.1"


### PR DESCRIPTION
- 前提：APIからカテゴリ情報(「その他」含む)が返してくれる
  - カテゴリの一覧表示(APIから取得)
  - カテゴリの追加
  - カテゴリの名前編集
  - カテゴリの無効化
  - カテゴリの削除
  - カテゴリの順序変更
  - カテゴリの編集保存(APIに送信)